### PR TITLE
Impersonate with no access to talk

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -20,7 +20,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-
+if(!\OC::$server->getSession()->get('oldUserId'))		
 return [
 	'routes' => [
 		[

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -143,35 +143,36 @@ class Application extends App implements IBootstrap {
 
 	public function boot(IBootContext $context): void {
 		$server = $context->getServerContainer();
+		if (!$server->getSession()->get('oldUserId')) {
+			$this->registerNotifier($server);
+			$this->registerCollaborationResourceProvider($server);
+			$this->registerClientLinks($server);
+			$this->registerNavigationLink($server);
 
-		$this->registerNotifier($server);
-		$this->registerCollaborationResourceProvider($server);
-		$this->registerClientLinks($server);
-		$this->registerNavigationLink($server);
+			/** @var IEventDispatcher $dispatcher */
+			$dispatcher = $server->query(IEventDispatcher::class);
 
-		/** @var IEventDispatcher $dispatcher */
-		$dispatcher = $server->query(IEventDispatcher::class);
+			ActivityListener::register($dispatcher);
+			NotificationListener::register($dispatcher);
+			SystemMessageListener::register($dispatcher);
+			ParserListener::register($dispatcher);
+			PublicShareAuthListener::register($dispatcher);
+			FilesListener::register($dispatcher);
+			FilesTemplateLoader::register($dispatcher);
+			RestrictStartingCallsListener::register($dispatcher);
+			RoomShareProvider::register($dispatcher);
+			SignalingListener::register($dispatcher);
+			CommandListener::register($dispatcher);
+			CollaboratorsListener::register($dispatcher);
+			ResourceListener::register($dispatcher);
+			ChangelogListener::register($dispatcher);
+			ShareListener::register($dispatcher);
+			StatusListener::register($dispatcher);
 
-		ActivityListener::register($dispatcher);
-		NotificationListener::register($dispatcher);
-		SystemMessageListener::register($dispatcher);
-		ParserListener::register($dispatcher);
-		PublicShareAuthListener::register($dispatcher);
-		FilesListener::register($dispatcher);
-		FilesTemplateLoader::register($dispatcher);
-		RestrictStartingCallsListener::register($dispatcher);
-		RoomShareProvider::register($dispatcher);
-		SignalingListener::register($dispatcher);
-		CommandListener::register($dispatcher);
-		CollaboratorsListener::register($dispatcher);
-		ResourceListener::register($dispatcher);
-		ChangelogListener::register($dispatcher);
-		ShareListener::register($dispatcher);
-		StatusListener::register($dispatcher);
-
-		$this->registerRoomActivityHooks($dispatcher);
-		$this->registerChatHooks($dispatcher);
-		$context->injectFn(\Closure::fromCallable([$this, 'registerCloudFederationProviderManager']));
+			$this->registerRoomActivityHooks($dispatcher);
+			$this->registerChatHooks($dispatcher);
+			$context->injectFn(\Closure::fromCallable([$this, 'registerCloudFederationProviderManager']));
+		}
 	}
 
 	protected function registerNotifier(IServerContainer $server): void {

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -185,7 +185,9 @@ class PageController extends Controller {
 	 * @return TemplateResponse|RedirectResponse
 	 * @throws HintException
 	 */
-	public function index(string $token = '', string $callUser = '', string $password = ''): Response {
+	public function index(string $token = '', string $callUser = '', string $password = ''): Response {		
+		if(\OC::$server->getSession()->get('oldUserId'))		
+			return new RedirectResponse($this->url->getBaseUrl());
 		$user = $this->userSession->getUser();
 		if (!$user instanceof IUser) {
 			return $this->guestEnterRoom($token, $password);
@@ -303,6 +305,8 @@ class PageController extends Controller {
 	 * @throws HintException
 	 */
 	protected function guestEnterRoom(string $token, string $password): Response {
+		if(\OC::$server->getSession()->get('oldUserId'))		
+			return new RedirectResponse($this->url->getBaseUrl());
 		try {
 			$room = $this->manager->getRoomByToken($token);
 			if ($room->getType() !== Room::TYPE_PUBLIC) {
@@ -373,6 +377,8 @@ class PageController extends Controller {
 	 * @return RedirectResponse
 	 */
 	protected function redirectToConversation(string $token): RedirectResponse {
+		if(\OC::$server->getSession()->get('oldUserId'))		
+			return new RedirectResponse($this->url->getBaseUrl());
 		// These redirects are already done outside of this method
 		if ($this->userId === null) {
 			try {

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -185,9 +185,7 @@ class PageController extends Controller {
 	 * @return TemplateResponse|RedirectResponse
 	 * @throws HintException
 	 */
-	public function index(string $token = '', string $callUser = '', string $password = ''): Response {		
-		if(\OC::$server->getSession()->get('oldUserId'))		
-			return new RedirectResponse($this->url->getBaseUrl());
+	public function index(string $token = '', string $callUser = '', string $password = ''): Response {
 		$user = $this->userSession->getUser();
 		if (!$user instanceof IUser) {
 			return $this->guestEnterRoom($token, $password);
@@ -305,8 +303,6 @@ class PageController extends Controller {
 	 * @throws HintException
 	 */
 	protected function guestEnterRoom(string $token, string $password): Response {
-		if(\OC::$server->getSession()->get('oldUserId'))		
-			return new RedirectResponse($this->url->getBaseUrl());
 		try {
 			$room = $this->manager->getRoomByToken($token);
 			if ($room->getType() !== Room::TYPE_PUBLIC) {
@@ -377,8 +373,6 @@ class PageController extends Controller {
 	 * @return RedirectResponse
 	 */
 	protected function redirectToConversation(string $token): RedirectResponse {
-		if(\OC::$server->getSession()->get('oldUserId'))		
-			return new RedirectResponse($this->url->getBaseUrl());
 		// These redirects are already done outside of this method
 		if ($this->userId === null) {
 			try {


### PR DESCRIPTION
### Changes

Blocks access to Talk while an impersonate session is active 

### Test

1. Impersonate an user
2. It shouldn't be possible to see the talk app icon, access it via /apps/spreed, call pages and API