### PR TITLE
Change notification priority for new talk rooms

### DIFF
--- a/lib/Controller/RoomController.php
+++ b/lib/Controller/RoomController.php
@@ -810,6 +810,9 @@ class RoomController extends AEnvironmentAwareController {
 		// Create the room
 		try {
 			$room = $this->roomService->createConversation($roomType, $roomName, $currentUser);
+			$participant = $this->participantService->getSessionsAndParticipantsForRoom($room)[0];
+			$this->setParticipant($participant);
+			$this->setNotificationLevel(1);
 		} catch (InvalidArgumentException $e) {
 			return new DataResponse([], Http::STATUS_BAD_REQUEST);
 		}


### PR DESCRIPTION
### Changes
Change notification priority for new talk rooms, so all new messages will be notified.

### Testing 

1. Book a new session via the calendar. 
2. Add a talk room to it. 
3. Check the notifications under the room settings and it should be set to All messages