### PR TITLE
Disable

### DIFF
--- a/lib/Room.php
+++ b/lib/Room.php
@@ -221,7 +221,7 @@ class Room {
 		$this->type = $type;
 		$this->readOnly = $readOnly;
 		$this->listable = $listable;
-		$this->lobbyState = $lobbyState;
+		$this->lobbyState = 0;
 		$this->sipEnabled = $sipEnabled;
 		$this->assignedSignalingServer = $assignedSignalingServer;
 		$this->token = $token;
@@ -261,7 +261,7 @@ class Room {
 
 	public function getLobbyState(): int {
 		$this->validateTimer();
-		return $this->lobbyState;
+		return 0;
 	}
 
 	public function getSIPEnabled(): int {


### PR DESCRIPTION
### Changes

Forces the state of the lobby to 0, disabling it

### Testing

1. Create and confirm a booking using the appointments app (via widget or external page)
2. Enter as a guest and you should be able to access it directly without having to wait on the lobby